### PR TITLE
[update] trashed items can be restored to any path

### DIFF
--- a/trash.go
+++ b/trash.go
@@ -58,7 +58,10 @@ func addTrashRoutes(r chi.Router) {
 		}
 
 		deletedPath := obj.Path[1:]
-		restorePath := path.Dir(obj.Path[1:])
+		restorePath := r.Form.Get("target")
+		if restorePath == "" {
+			restorePath = path.Dir(obj.Path[1:])
+		}
 		// check restore folder
 		newRoot := 0
 		conn.Get(&newRoot, "SELECT id FROM entity WHERE path = ? AND tree = ?", restorePath, User.Root)


### PR DESCRIPTION
trashed items can be restored by drag-n-drop from trash to a folder in a tree and to any path opened in Double mode on the other side